### PR TITLE
Add support for assetPrefix option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
+      const assetPrefix = nextConfig.assetPrefix || "";
+
       config.module.rules.push({
         test: /\.(jpe?g|png|svg|gif)$/,
         use: [
@@ -15,7 +17,7 @@ module.exports = (nextConfig = {}) => {
             options: {
               limit: 8192,
               fallback: "file-loader",
-              publicPath: "/_next/static/images/",
+              publicPath: `${assetPrefix}/_next/static/images/`,
               outputPath: "static/images/",
               name: "[name]-[hash].[ext]"
             }


### PR DESCRIPTION
Next.js has an `assetPrefix` for CDNs and though you can set it for its own assets, it has no effect on webpack. Just a quick suggestion here to allow for optionally passing this as an option in case projects need to set their own CDN or absolute domain location on render.