### PR TITLE
Allow setting `inlineImageLimit` value to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,13 @@ module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       const { isServer } = options;
+      nextConfig = Object.assign({ inlineImageLimit: 8192, assetPrefix: "" }, nextConfig);
+
       if (!options.defaultLoaders) {
         throw new Error(
           'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
         )
       }
-
-      const assetPrefix = nextConfig.assetPrefix || "";
-      const limit = nextConfig.inlineImageLimit || 8192;
 
       config.module.rules.push({
         test: /\.(jpe?g|png|svg|gif|ico)$/,
@@ -17,9 +16,9 @@ module.exports = (nextConfig = {}) => {
           {
             loader: "url-loader",
             options: {
-              limit,
+              limit: nextConfig.inlineImageLimit,
               fallback: "file-loader",
-              publicPath: `${assetPrefix}/_next/static/images/`,
+              publicPath: `${nextConfig.assetPrefix}/_next/static/images/`,
               outputPath: `${isServer ? "../" : ""}static/images/`,
               name: "[name]-[hash].[ext]"
             }


### PR DESCRIPTION
`0` being falsy, the previous default parameter logic was overwriting the value. This disallowed user to disable image inlining.