### PR TITLE
Resolve loaders relative to next-images

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ module.exports = (nextConfig = {}) => {
         exclude: nextConfig.exclude,
         use: [
           {
-            loader: "url-loader",
+            loader: require.resolve("url-loader"),
             options: {
               limit: nextConfig.inlineImageLimit,
-              fallback: "file-loader",
+              fallback: require.resolve("file-loader"),
               publicPath: `${nextConfig.assetPrefix}/_next/static/images/`,
               outputPath: `${isServer ? "../" : ""}static/images/`,
               name: "[name]-[hash].[ext]"


### PR DESCRIPTION
This fixes an issue where url-loader cannot be resolved when using
strict package managers such as pnpm or yarn pnp:

    Module not found: Can't resolve 'url-loader' in '/path/to/project'

Most users don't notice this because npm and yarn by default hoist
transitive dependencies to the root, so url-loader can be resolved from
the app's webpack config:

    node_modules/
      next-images/
      url-loader/
      file-loader/

However, more strict package managers do not perform hoisting:

    node_modules/
      next-images/
        node_modules/
          url-loader/
          file-loader/

So 'url-loader' cannot be resolved from the root.