### PR TITLE
Support Webpack v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,8 @@ module.exports = (nextConfig = {}) => {
 
       config.module.rules.push({
         test: /\.(jpe?g|png|svg|gif|ico|webp|jp2)$/,
-        issuer: {
-          // Next.js already handles url() in css/sass/scss files
-          test: /\.\w+(?<!(s?c|sa)ss)$/i,
-        },
+        // Next.js already handles url() in css/sass/scss files
+        issuer: /\.\w+(?<!(s?c|sa)ss)$/i,
         exclude: nextConfig.exclude,
         use: [
           {


### PR DESCRIPTION
Condition type `{ test: Condition }` is not supported anymore

###### Reference
- https://github.com/webpack/webpack/pull/10557