### PR TITLE
fix(deps): add 'webpack' to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "file-loader": "^6.0.0",
     "url-loader": "^4.0.0"
+  },
+  "peerDependencies": {
+    "webpack": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
Enables Yarn v2 support and gets rid of Yarn v1 warnings that:

```
next-images@npm:1.4.1 doesn't provide webpack@^4.0.0 || ^5.0.0 requested by file-loader@npm:6.0.0
next-images@npm:1.4.1 doesn't provide webpack@^4.0.0 || ^5.0.0 requested by url-loader@npm:4.1.0
```