### PR TITLE
Allow the ability to control the file suffixes `next-images` cares about

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![npm](https://img.shields.io/david/arefaslani/next-images.svg)
 
 Import images in [Next.js](https://github.com/zeit/next.js)
-(jpg, jpeg, svg, png, ico, webp and gif images)
+(jpg, jpeg, png, svg, fig, ico, webp, and jp2 images by default).
 
 ## Features
 * Load images from local computer
@@ -111,6 +111,27 @@ module.exports = withImages({
   }
 })
 ```
+
+### File Extensions
+You have the power to specifiy the file extensions you'd like to pass to this loader configuration. This is helpful for
+adding image types that behave similarly, but are not included by default. It's also helpful in the same way that
+`exclude` is helpful, because you can exclude all SVGs (not just one from a specific folder).
+
+**Please note**: If you have issues with a file suffix not included in our default list
+(["jpg", "jpeg", "png", "svg", "gif", "ico", "webp", "jp2"]), we won't be able to gaurantee bug support.
+
+Example usage:
+```js
+// next.config.js
+const withImages = require('next-images')
+module.exports = withImages({
+  fileExtensions: ["jpg", "jpeg", "png", "gif"],
+  webpack(config, options) {
+    return config
+  }
+})
+```
+
 
 ### ES Modules
 > By default, file-loader generates JS modules that use the ES modules syntax. There are some cases in which using ES modules is beneficial, like in the case of module concatenation and tree shaking.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@ module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       const { isServer } = options;
-      nextConfig = Object.assign({ inlineImageLimit: 8192, assetPrefix: "", basePath: "" }, nextConfig);
+      nextConfig = Object.assign({
+        inlineImageLimit: 8192,
+        assetPrefix: "",
+        basePath: "",
+        fileExtensions: ["jpg", "jpeg", "png", "svg", "gif", "ico", "webp", "jp2"],
+      }, nextConfig);
 
       if (!options.defaultLoaders) {
         throw new Error(
@@ -11,7 +16,7 @@ module.exports = (nextConfig = {}) => {
       }
 
       config.module.rules.push({
-        test: /\.(jpe?g|png|svg|gif|ico|webp|jp2)$/,
+        test: new RegExp(`\.(${fileExtensions.join('|')})$`),
         // Next.js already handles url() in css/sass/scss files
         issuer: /\.\w+(?<!(s?c|sa)ss)$/i,
         exclude: nextConfig.exclude,


### PR DESCRIPTION
Resolves https://github.com/twopluszero/next-images/issues/24
(even though it's already closed 😅 )

I don't want to force my team into putting SVGs into one specific folder. I like the simplicity of `next-images` for most image types, but I'm using SVGR for `.svg` file types. This lets me exclude SVGs from `next-image`'s concern, but still place SVG files wherever I please.

## Alternative

If this isn't ideal for the library author, I could also do a non-breaking change where `exclude` can be an array of the possible file types, and construct the regex in a similar fashion. In other words, if `Array.isArray(nextConfig.excludes)`, then dont add the exclude property to the loader and - instead - remove each item in the `excludes` array from the `test` regex.