### PR TITLE
Adds note on using with next/image component

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,15 @@ Typescript doesn't know how interpret imported images. `next-images` package con
 
 + /// <reference types="next-images" />
 ```
+
+### With `next/image`
+
+Base4/Data URL encoding is not supported when using the `next/image` component for image optimization. To deactivate inline images you can set the `inlineImageLimit` to `false`:
+
+```js
+// next.config.js
+const withImages = require('next-images')
+module.exports = withImages({
+  inlineImageLimit: false
+})
+```


### PR DESCRIPTION
Hi! Thanks for the package. Use it a lot and love it for creating semantically grouped resources in feature folders!

Today Vercel announced Next.js 10.0.0. In 10.0.0 you have the [`next/image`](https://nextjs.org/docs/api-reference/next/image) component which optimizes images either through servers, external loaders, or Vercel. In any case, it seems to work with `next-images` and resolving images not placed in `public/` folder. However, obviously, it doesn't play well with Data URLs and thus there can be some issues with the default value of inline images with this package. Also, I think much of the cases where Data URLs are handy can be optimized better with coachable generated webp files. So this PR adds a note on using with `next/image` component and recommends deactivating inline images entirely when doing so.