### PR TITLE
Make configuration of dynamic asset prefix easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ You can serve remote images by setting ***assetPrefix*** option.
 
 Dynamic (runtime) asset prefixes are also supported, you can enable this feature by setting ***dynamicAssetPrefix*** to `true`.
 
+> :warning: **If you are using dynamic asset prefixes**: Dynamic (runtime) asset prefixing is heavily based on public [runtime configuration](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) feature of Next.js which means your project cannot have any statically generated pages if you enable dynamic asset prefixes.
+
 Example usage:
 ```js
 // next.config.js

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = ({ dynamicAssetPrefix = false, ...nextConfig } = {}) => {
             options: {
               limit: nextConfig.inlineImageLimit,
               fallback: require.resolve("file-loader"),
-              publicPath: `${(dynamicAssetPrefix ? '' : nextConfig.assetPrefix) || nextConfig.basePath}/_next/static/images/`,
+              publicPath: `${dynamicAssetPrefix ? '' : nextConfig.assetPrefix || nextConfig.basePath}/_next/static/images/`,
               outputPath: `${isServer ? "../" : ""}static/images/`,
               postTransformPublicPath: (p) => {
                 if (dynamicAssetPrefix) {

--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ module.exports = ({ dynamicAssetPrefix = false, ...nextConfig } = {}) => {
             options: {
               limit: nextConfig.inlineImageLimit,
               fallback: require.resolve("file-loader"),
-              publicPath: `${nextConfig.assetPrefix || nextConfig.basePath}/_next/static/images/`,
+              publicPath: `${(dynamicAssetPrefix ? '' : nextConfig.assetPrefix) || nextConfig.basePath}/_next/static/images/`,
               outputPath: `${isServer ? "../" : ""}static/images/`,
               postTransformPublicPath: (p) => {
-                if (dynamicAssetPrefix && !nextConfig.assetPrefix) {
+                if (dynamicAssetPrefix) {
                   return `(require("next/config").default().publicRuntimeConfig.nextImagesAssetPrefix || '') + ${p}`
                 }
                 return p

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-images",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
This PR tries to make the usage of Dynamic Asset Prefix feature more clear. From now on if `dynamicAssetPrefix` field in `next.config.js` is set to `true` we will always produce a dynamic url (based on the `assetPrefix` extracted from Next.js runtime config) for imported images during transpilation. Unlike before we do not check during transpilation if `assetPrefix` field is defined or not in the `next.config.js`.