### PR TITLE
Add `name` option to allow overriding the default of "[name]-[hash].[ext]"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ module.exports = withImages({
 })
 ```
 
+### Name
+You can change the structure of the generated file names by passing the `name` option:
+
+```js
+// next.config.js
+const withImages = require('next-images')
+module.exports = withImages({
+  name: "[name].[hash:base64:8].[ext]",
+  webpack(config, options) {
+    return config
+  }
+})
+```
+
+The default value is `"[name]-[hash].[ext]"`.  Documentation for available tokens like `[name]`, `[hash]`, etc can be found in [webpack/loader-utils](https://github.com/webpack/loader-utils#interpolatename)
 
 ### ES Modules
 > By default, file-loader generates JS modules that use the ES modules syntax. There are some cases in which using ES modules is beneficial, like in the case of module concatenation and tree shaking.

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = ({ dynamicAssetPrefix = false, ...nextConfig } = {}) => {
                       ''
                     }/_next/static/images/`,
                   }),
-              name: "[name]-[hash].[ext]",
+              name: nextConfig.name || "[name]-[hash].[ext]",
               esModule: nextConfig.esModule || false
             }
           }


### PR DESCRIPTION
I've [patched this into one of my projects](https://github.com/fracture91/ahurle-dev/blob/a6cc816533e6091d38a0ea5897b3ee5d911e2e6c/patches/next-images%2B1.7.0.patch) and [configured it thusly](https://github.com/fracture91/ahurle-dev/blob/a6cc816533e6091d38a0ea5897b3ee5d911e2e6c/next.config.js#L29-L31).  Seems to work as intended.