### PR TITLE
Fix the regex used for `test` in the webpack rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = ({ dynamicAssetPrefix = false, ...nextConfig } = {}) => {
       }
 
       config.module.rules.push({
-        test: new RegExp(`\.(${nextConfig.fileExtensions.join('|')})$`),
+        test: new RegExp(`\\.(${nextConfig.fileExtensions.join('|')})$`),
         // Next.js already handles url() in css/sass/scss files
         issuer: /\.\w+(?<!(s?c|sa)ss)$/i,
         exclude: nextConfig.exclude,


### PR DESCRIPTION
The period wasn't getting escaped properly and was matching any character. This fixes #77.